### PR TITLE
feat: print version number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use time::format_description::{parse_owned, parse_strftime_owned};
 static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
 struct Args {
     file: String,
     /// Collect data and exit, intended for profiling


### PR DESCRIPTION
```
$ logsmash --help
Usage: logsmash [OPTIONS] <FILE>

Arguments:
  <FILE>  

Options:
      --profile                    Collect data and exit, intended for profiling
      --date-format <DATE_FORMAT>  Date format to use when parsing log lines
  -h, --help                       Print help
  -V, --version                    Print version

```

```
$ logsmash --version
logsmash 0.1.10
```